### PR TITLE
[#8] 업비트 WebSocket DataBuffer 이중 해제 수정

### DIFF
--- a/src/main/java/ksh/tryptocollector/exchange/upbit/UpbitWebSocketHandler.java
+++ b/src/main/java/ksh/tryptocollector/exchange/upbit/UpbitWebSocketHandler.java
@@ -8,7 +8,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.buffer.DataBuffer;
-import org.springframework.core.io.buffer.DataBufferUtils;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.socket.WebSocketMessage;
 import org.springframework.web.reactive.socket.client.ReactorNettyWebSocketClient;
@@ -81,7 +80,6 @@ public class UpbitWebSocketHandler implements ExchangeTickerStream {
         DataBuffer buffer = message.getPayload();
         byte[] bytes = new byte[buffer.readableByteCount()];
         buffer.read(bytes);
-        DataBufferUtils.release(buffer);
         return bytes;
     }
 


### PR DESCRIPTION
## Summary
- `UpbitWebSocketHandler.extractPayload()`에서 `DataBufferUtils.release(buffer)` 제거
- Spring WebFlux가 리액티브 스트림 생명주기를 통해 DataBuffer를 자동 관리하므로 수동 release가 이중 해제를 유발

## Test plan
- [x] E2E 테스트: 업비트 WebSocket 연결 유지 확인, Redis에 59개 티커 정상 저장
Closes #8