### PR TITLE
[#9] 빗썸 WebSocket URL 신규 엔드포인트로 변경

### DIFF
--- a/docs/bithumb.md
+++ b/docs/bithumb.md
@@ -45,7 +45,7 @@ market: "KRW-BTC"
 
 ### 연결 정보
 
-- **URL:** `wss://pubwss.bithumb.com/pub/ws`
+- **URL:** `wss://ws-api.bithumb.com/websocket/v1`
 - **프레임 유형:** 텍스트 (업비트와 달리 바이너리/gzip이 아님)
 - **구독 메시지:** 연결 직후 JSON 배열로 전송
 
@@ -81,7 +81,7 @@ market: "KRW-BTC"
 
 | 항목 | 업비트 | 빗썸 |
 |------|--------|------|
-| WebSocket URL | `wss://api.upbit.com/websocket/v1` | `wss://pubwss.bithumb.com/pub/ws` |
+| WebSocket URL | `wss://api.upbit.com/websocket/v1` | `wss://ws-api.bithumb.com/websocket/v1` |
 | 프레임 유형 | 바이너리 (gzip 가능) | 텍스트 |
 | 구독 형식 | 동일 | 동일 |
 | 응답 필드 | 동일 | 동일 |

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,7 +17,7 @@ exchange:
     ws-url: wss://api.upbit.com/websocket/v1
   bithumb:
     rest-url: https://api.bithumb.com/v1/market/all?isDetails=false
-    ws-url: wss://pubwss.bithumb.com/pub/ws
+    ws-url: wss://ws-api.bithumb.com/websocket/v1
   binance:
     rest-url: https://api.binance.com/api/v3/ticker/24hr
     ws-url: wss://stream.binance.com:9443/ws/!miniTicker@arr


### PR DESCRIPTION
## Summary
- `application.yml`의 빗썸 WebSocket URL을 `wss://ws-api.bithumb.com/websocket/v1`로 변경
- `docs/bithumb.md` 문서 동기화 (구 URL 2곳 수정)

## Test plan
- [x] E2E 테스트: 빗썸 WebSocket 연결 성공, Redis에 42개 티커 정상 저장 (BTC/KRW: 106,369,000원)

Closes #9